### PR TITLE
Update eslint to use v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,21 @@
 {
   "name": "t3st",
-  "version": "2020.10.19",
-  "lockfileVersion": 1,
+  "version": "2024.05.28",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "clia": {
+  "packages": {
+    "": {
+      "name": "t3st",
+      "version": "2024.05.28",
+      "license": "MIT",
+      "dependencies": {
+        "clia": "^2020.8.11"
+      },
+      "bin": {
+        "t3st": "bin/cli.js"
+      }
+    },
+    "node_modules/clia": {
       "version": "2020.8.11",
       "resolved": "https://registry.npmjs.org/clia/-/clia-2020.8.11.tgz",
       "integrity": "sha512-KyNemrLNXpTn/eAZ27oDURrF57T4T8jc0fkTIQAALfXII/vbFbCBNGZXU8Neo+rQbzZ4ha+mmzCcXzFUZnJinA=="

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "t3st",
-  "version": "2024.05.16",
+  "version": "2024.05.28",
   "description": "A minimal javascript test framework",
   "files": [
     "/bin",
@@ -11,7 +11,7 @@
   "bin": "./bin/cli.js",
   "scripts": {
     "test": "(node bin/cli.js) && (node bin/cli.js --dir tests-external/tests)",
-    "lint": "npx eslint@7 .",
+    "lint": "npx eslint@9 . --ignore-pattern '**/invalid_javascript.js'",
     "push": "npm run lint && npm run test && git push"
   },
   "repository": {

--- a/tests-external/all_ok/all_ok.js
+++ b/tests-external/all_ok/all_ok.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-sparse-arrays */
 module.exports = ({ test, equal, check }) => [
     test("ok", () => true),
     test("also ok", () => { equal(1, 1) }),

--- a/tests/check.js
+++ b/tests/check.js
@@ -27,17 +27,13 @@ module.exports = ({ test, throws, equal, check }) => {
             equal(true, err.message.includes('expected (...values [, function => boolean]'))
         })
         , throws("includes error message of invalid assertion", () => {
-            /* eslint-disable no-undef */
             check(() => _undefined)
-            /* eslint-enable no-undef */
         }, (err) => {
             check(err.message, (m) => m.includes("ReferenceError: _undefined is not defined"))
             check(err.message, (m) => m.includes("failed *before* assertion"))
         })
         , throws("test catches error in check proposition arguments", () => {
-            /* eslint-disable no-undef */
             check(_undefined, (_n, _a) => true)
-            /* eslint-enable no-undef */
         }, (err) => {
             check(err + '', (err) => err.includes("ReferenceError: _undefined is not defined"))
             check(err + '', (err) => false === err.includes("failed *before* assertion"))

--- a/tests/result_text.js
+++ b/tests/result_text.js
@@ -16,9 +16,7 @@ module.exports = ({ test, equal, check }) => {
 
     const result_tests = [
         test("error is included in error message", () => {
-            /* eslint-disable no-undef */
             const err_undefined = test("_", () => { _undefined })
-            /* eslint-disable no-undef */
             check(() => result_text(err_undefined).message.includes('ReferenceError: _undefined is not defined'))
 
             const err_string = test("_", () => { throw 'err-msg' })

--- a/tests/text_summize.js
+++ b/tests/text_summize.js
@@ -4,7 +4,6 @@ module.exports = ({ test, equal, check }) => {
     const report_silent = (results) => report({ results, silent: true })
 
     const results_empty = []
-    // eslint-disable-next-line no-sparse-arrays
     const mixed_empty = [,,[,,[[,,],],,],,,]
     const results_single_success = [{ description: "mkay fine" }]
 


### PR DESCRIPTION
eslint.config.js `ignores` specifies files to exclude form linting, but still parses them.